### PR TITLE
Inventory Price API

### DIFF
--- a/src/main/scala/de/hpi/epic/pricewars/data/HoldingCostRate.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/data/HoldingCostRate.scala
@@ -1,0 +1,3 @@
+package de.hpi.epic.pricewars.data
+
+case class HoldingCostRate(rate: BigDecimal, merchant_id: Option[String])

--- a/src/main/scala/de/hpi/epic/pricewars/data/InventoryPrice.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/data/InventoryPrice.scala
@@ -1,3 +1,0 @@
-package de.hpi.epic.pricewars.data
-
-case class InventoryPrice(price: BigDecimal, merchant_id: Option[String])

--- a/src/main/scala/de/hpi/epic/pricewars/data/InventoryPrice.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/data/InventoryPrice.scala
@@ -1,0 +1,3 @@
+package de.hpi.epic.pricewars.data
+
+case class InventoryPrice(price: BigDecimal, merchant_id: Option[String])

--- a/src/main/scala/de/hpi/epic/pricewars/services/DatabaseStore.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/services/DatabaseStore.scala
@@ -355,7 +355,7 @@ object DatabaseStore {
     }
   }
 
-  def addMerchant(merchant: Merchant, inventory_price: BigDecimal): Result[Merchant] = {
+  def addMerchant(merchant: Merchant, holdingCostRate: BigDecimal): Result[Merchant] = {
     val res = Try(DB localTx { implicit session =>
       sql"""WITH token AS (SELECT random_string(64) AS value),
              token_hash AS (SELECT encode(digest(token.value, 'sha256'), 'base64') AS value FROM token)
@@ -372,7 +372,7 @@ object DatabaseStore {
       case scala.util.Success(created_merchant) =>
         val timestamp = new DateTime()
         kafka_producer.send(KafkaProducerRecord("addMerchant", s"""{"merchant_id": "${created_merchant.merchant_id.get}", "api_endpoint_url": "${merchant.api_endpoint_url}", "merchant_name": "${merchant.merchant_name}", "algorithm_name": "${merchant.algorithm_name}", "http_code": 200, "timestamp": "$timestamp"}"""))
-        changeInventoryPrice(inventory_price, created_merchant.merchant_id.get, timestamp)
+        changeHoldingCostRate(holdingCostRate, created_merchant.merchant_id.get, timestamp)
         Success(merchant.copy(merchant_id = created_merchant.merchant_id, merchant_token = created_merchant.merchant_token))
       case scala.util.Failure(e) =>
         kafka_producer.send(KafkaProducerRecord("addMerchant", s"""{"api_endpoint_url": "${merchant.api_endpoint_url}", "merchant_name": "${merchant.merchant_name}", "algorithm_name": "${merchant.algorithm_name}", "http_code": 500, "timestamp": "${new DateTime()}"}"""))
@@ -773,8 +773,8 @@ object DatabaseStore {
     }
   }
 
-  def changeInventoryPrice(price: BigDecimal, merchant_id: String, timestamp: DateTime = new DateTime): Unit = {
-    kafka_producer.send(KafkaProducerRecord("inventory_prices",
-      s"""{"merchant_id": "$merchant_id", "price_per_minute": $price, "timestamp": "$timestamp"}"""))
+  def changeHoldingCostRate(rate: BigDecimal, merchant_id: String, timestamp: DateTime = new DateTime): Unit = {
+    kafka_producer.send(KafkaProducerRecord("holding_cost_rate",
+      s"""{"merchant_id": "$merchant_id", "rate": $rate, "timestamp": "$timestamp"}"""))
   }
 }

--- a/src/main/scala/de/hpi/epic/pricewars/services/MarketplaceService.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/services/MarketplaceService.scala
@@ -17,6 +17,7 @@ class MarketplaceServiceActor extends Actor with ActorLogging with MarketplaceSe
 }
 
 trait MarketplaceService extends HttpService with CORSSupport {
+  var default_inventory_price: BigDecimal = 0
   val route: Route = respondWithMediaType(MediaTypes.`application/json`) {
     logRequestResponse("marketplace", Logging.InfoLevel) {
       cors {
@@ -144,7 +145,7 @@ trait MarketplaceService extends HttpService with CORSSupport {
                 entity(as[Merchant]) { merchant =>
                   detach() {
                     complete {
-                      DatabaseStore.addMerchant(merchant).successHttpCode(StatusCodes.Created)
+                      DatabaseStore.addMerchant(merchant, default_inventory_price).successHttpCode(StatusCodes.Created)
                     }
                   }
                 }
@@ -293,7 +294,22 @@ trait MarketplaceService extends HttpService with CORSSupport {
                   }
                 }
               }
+          } ~
+        path("inventory_price") {
+          put {
+            entity(as[InventoryPrice]) { inventory_price =>
+              inventory_price.merchant_id match {
+                case Some(id) =>
+                  DatabaseStore.changeInventoryPrice(inventory_price.price, id)
+                case None =>
+                  default_inventory_price = inventory_price.price
+              }
+              complete {
+                StatusCode.int2StatusCode(200) -> s"""{}"""
+              }
+            }
           }
+        }
       }
     }
   }

--- a/src/main/scala/de/hpi/epic/pricewars/services/MarketplaceService.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/services/MarketplaceService.scala
@@ -17,7 +17,7 @@ class MarketplaceServiceActor extends Actor with ActorLogging with MarketplaceSe
 }
 
 trait MarketplaceService extends HttpService with CORSSupport {
-  var default_inventory_price: BigDecimal = 0
+  var defaultHoldingCostRate: BigDecimal = 0
   val route: Route = respondWithMediaType(MediaTypes.`application/json`) {
     logRequestResponse("marketplace", Logging.InfoLevel) {
       cors {
@@ -145,7 +145,7 @@ trait MarketplaceService extends HttpService with CORSSupport {
                 entity(as[Merchant]) { merchant =>
                   detach() {
                     complete {
-                      DatabaseStore.addMerchant(merchant, default_inventory_price).successHttpCode(StatusCodes.Created)
+                      DatabaseStore.addMerchant(merchant, defaultHoldingCostRate).successHttpCode(StatusCodes.Created)
                     }
                   }
                 }
@@ -276,7 +276,7 @@ trait MarketplaceService extends HttpService with CORSSupport {
                 StatusCodes.OK ->
                   s"""{
                   "consumer_per_minute": ${ValidateLimit.getConsumerPerMinute},
-                  "max_updates_per_sale": ${ValidateLimit.getMaxUpdatesPerSale}, 
+                  "max_updates_per_sale": ${ValidateLimit.getMaxUpdatesPerSale},
                   "max_req_per_sec": ${ValidateLimit.getMaxReqPerSec}
                 }"""
               }
@@ -295,14 +295,14 @@ trait MarketplaceService extends HttpService with CORSSupport {
                 }
               }
           } ~
-        path("inventory_price") {
+        path("holding_cost_rate") {
           put {
-            entity(as[InventoryPrice]) { inventory_price =>
-              inventory_price.merchant_id match {
+            entity(as[HoldingCostRate]) { holdingCostRate =>
+              holdingCostRate.merchant_id match {
                 case Some(id) =>
-                  DatabaseStore.changeInventoryPrice(inventory_price.price, id)
+                  DatabaseStore.changeHoldingCostRate(holdingCostRate.rate, id)
                 case None =>
-                  default_inventory_price = inventory_price.price
+                  defaultHoldingCostRate = holdingCostRate.rate
               }
               complete {
                 StatusCode.int2StatusCode(200) -> s"""{}"""

--- a/src/main/scala/de/hpi/epic/pricewars/utils/JSONConverter.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/utils/JSONConverter.scala
@@ -2,7 +2,7 @@ package de.hpi.epic.pricewars.utils
 
 import de.hpi.epic.pricewars.data._
 import spray.httpx.SprayJsonSupport
-import spray.json.{DefaultJsonProtocol, JsonFormat}
+import spray.json.{DefaultJsonProtocol, JsonFormat, RootJsonFormat}
 
 object JSONConverter extends DefaultJsonProtocol with SprayJsonSupport {
   implicit val shippingTimeFormat = jsonFormat2(ShippingTime.apply)
@@ -13,5 +13,6 @@ object JSONConverter extends DefaultJsonProtocol with SprayJsonSupport {
   implicit val productFormat = jsonFormat3(Product.apply)
   implicit val buyRequestFormat = jsonFormat3(BuyRequest)
   implicit val settingsFormat = jsonFormat3(Settings)
+  implicit val inventoryPriceFormat: RootJsonFormat[InventoryPrice] = jsonFormat2(InventoryPrice)
   implicit def failureFormat[A :JsonFormat] = jsonFormat2(Failure.apply[A])
 }

--- a/src/main/scala/de/hpi/epic/pricewars/utils/JSONConverter.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/utils/JSONConverter.scala
@@ -13,6 +13,6 @@ object JSONConverter extends DefaultJsonProtocol with SprayJsonSupport {
   implicit val productFormat = jsonFormat3(Product.apply)
   implicit val buyRequestFormat = jsonFormat3(BuyRequest)
   implicit val settingsFormat = jsonFormat3(Settings)
-  implicit val inventoryPriceFormat: RootJsonFormat[InventoryPrice] = jsonFormat2(InventoryPrice)
+  implicit val holdingCostRateFormat: RootJsonFormat[HoldingCostRate] = jsonFormat2(HoldingCostRate)
   implicit def failureFormat[A :JsonFormat] = jsonFormat2(Failure.apply[A])
 }


### PR DESCRIPTION
Adds a new API route that makes it possible to change the inventory price.
The inventory price is the price per minute per unit in the inventory.
It is a parameter that controls the amount of resulting holding cost for a merchant.

Example:
```
POST /inventory_cost
price=5
merchant_id="g0MVqMJqqXtvzIk+rVS7cEwt+FDo9WveupoHfUmGuck="
```

This sets the inventory price of merchant with id `g0MVqMJqqXtvzIk+rVS7cEwt+FDo9WveupoHfUmGuck=` to 5.

merchant_id is an optional parameter.
When merchant_id is not provided, the call changes the starting inventory cost for all merchants that will register in future. This wont overwrite inventory prices for existing merchants.