### PR TITLE
GET route for holding cost rate

### DIFF
--- a/src/main/scala/de/hpi/epic/pricewars/connectors/MerchantConnector.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/connectors/MerchantConnector.scala
@@ -23,7 +23,7 @@ object MerchantConnector {
   val remove_merchant = config.getBoolean("remove_merchant_on_notification_error")
 
   def notifyMerchant(merchant: Merchant, offer_id: Long, amount: Int, price: BigDecimal, offer: Offer) = {
-    val json = s"""{"offer_id": $offer_id, "uid": ${offer.uid}, "product_id": ${offer.product_id}, "quality": ${offer.quality}, "amount_sold": $amount, "price_sold": $price, "price": ${offer.price}, "merchant_id": "${merchant.merchant_id.get}", "merchant_token": "${merchant.merchant_token.get}", "amount": ${offer.amount}}"""
+    val json = s"""{"offer_id": $offer_id, "uid": ${offer.uid}, "product_id": ${offer.product_id}, "quality": ${offer.quality}, "amount_sold": $amount, "price_sold": $price, "price": ${offer.price}, "merchant_id": "${merchant.merchant_id.get}", "amount": ${offer.amount}}"""
     val request = (IO(Http) ? HttpRequest(POST,
       Uri(merchant.api_endpoint_url + "/sold"),
       entity = HttpEntity(MediaTypes.`application/json`, json)

--- a/src/main/scala/de/hpi/epic/pricewars/data/Merchant.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/data/Merchant.scala
@@ -11,5 +11,9 @@ case class Merchant( api_endpoint_url: String,
 object Merchant extends SQLSyntaxSupport[Merchant] {
   override val tableName = "merchants"
   def apply(rs: WrappedResultSet) = new Merchant(
-    rs.string("api_endpoint_url"), rs.string("merchant_name"), rs.string("algorithm_name"), rs.stringOpt("merchant_id"), rs.stringOpt("merchant_token"))
+    rs.string("api_endpoint_url"),
+    rs.string("merchant_name"),
+    rs.string("algorithm_name"),
+    rs.stringOpt("merchant_id"),
+    rs.stringOpt("merchant_token"))
 }

--- a/src/main/scala/de/hpi/epic/pricewars/services/DatabaseStore.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/services/DatabaseStore.scala
@@ -219,7 +219,7 @@ object DatabaseStore {
 
     var merchant: Option[Merchant] = None
     var merchant_id: String = ""
-    offerResult.flatMap(offer => DatabaseStore.getMerchant(offer.merchant_id.get, return_token = true)) match {
+    offerResult.flatMap(offer => DatabaseStore.getMerchant(offer.merchant_id.get)) match {
       case Success(merchantFound) => {
         merchant = Some(merchantFound)
         merchant_id = merchantFound.merchant_id.getOrElse("")
@@ -470,55 +470,24 @@ object DatabaseStore {
     }
   }
 
-  def getMerchant(search_parameter: String, search_with_token: Boolean = false, return_token: Boolean = false): Result[Merchant] = {
+  def getMerchant(id: String): Result[Merchant] = {
     val res = Try(DB readOnly { implicit session =>
-      var sql_query = sql""
-      if (!search_with_token && !return_token) {
-        sql_query =
-          sql"""SELECT merchant_id, api_endpoint_url, merchant_name, algorithm_name, NULL AS merchant_token
-          FROM merchants
-          WHERE merchant_id = $search_parameter"""
-      } else if (!search_with_token && return_token) {
-        sql_query =
-          sql"""SELECT merchant_id, api_endpoint_url, merchant_name, algorithm_name, merchant_token
-          FROM merchants
-          WHERE merchant_id = $search_parameter"""
-      } else if (search_with_token && !return_token) {
-        sql_query =
-          sql"""SELECT merchant_id, api_endpoint_url, merchant_name, algorithm_name, NULL AS merchant_token
-          FROM merchants
-          WHERE merchant_token = $search_parameter"""
-      } else if (search_with_token && return_token) {
-        sql_query =
-          sql"""SELECT merchant_id, api_endpoint_url, merchant_name, algorithm_name, merchant_token
-          FROM merchants
-          WHERE merchant_token = $search_parameter"""
-      }
+      val sql_query =
+        sql"""SELECT merchant_id, api_endpoint_url, merchant_name, algorithm_name, NULL AS merchant_token
+        FROM merchants
+        WHERE merchant_id = $id"""
       sql_query.map(rs => Merchant(rs)).list.apply().headOption
     })
     res match {
-      case scala.util.Success(Some(v)) => {
+      case scala.util.Success(Some(v)) =>
         kafka_producer.send(KafkaProducerRecord("getMerchant", s"""{"merchant_id": "${v.merchant_id.get}", "http_code": 200, "timestamp": "${new DateTime()}"}"""))
         Success(v)
-      }
-      case scala.util.Success(None) => {
-        if (!search_with_token) {
-          kafka_producer.send(KafkaProducerRecord("getMerchant", s"""{"merchant_id": "$search_parameter", "http_code": 404, "timestamp": "${new DateTime()}"}"""))
-          Failure(s"No merchant with key $search_parameter found", 404)
-        } else {
-          kafka_producer.send(KafkaProducerRecord("getMerchant", s"""{"merchant_token": "$search_parameter", "http_code": 404, "timestamp": "${new DateTime()}"}"""))
-          Failure(s"No merchant with token $search_parameter found", 404)
-        }
-      }
-      case scala.util.Failure(e) => {
-        if (!search_with_token) {
-          kafka_producer.send(KafkaProducerRecord("getMerchant", s"""{"merchant_id": "$search_parameter", "http_code": 500, "timestamp": "${new DateTime()}"}"""))
-          Failure(e.getMessage, 500)
-        } else {
-          kafka_producer.send(KafkaProducerRecord("getMerchant", s"""{"merchant_token": "$search_parameter", "http_code": 500, "timestamp": "${new DateTime()}"}"""))
-          Failure(e.getMessage, 500)
-        }
-      }
+      case scala.util.Success(None) =>
+        kafka_producer.send(KafkaProducerRecord("getMerchant", s"""{"merchant_id": "$id", "http_code": 404, "timestamp": "${new DateTime()}"}"""))
+        Failure(s"No merchant with key $id found", 404)
+      case scala.util.Failure(e) =>
+        kafka_producer.send(KafkaProducerRecord("getMerchant", s"""{"merchant_id": "$id", "http_code": 500, "timestamp": "${new DateTime()}"}"""))
+        Failure(e.getMessage, 500)
     }
   }
 

--- a/src/main/scala/de/hpi/epic/pricewars/services/DatabaseStore.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/services/DatabaseStore.scala
@@ -741,6 +741,21 @@ object DatabaseStore {
     }
   }
 
+  def getInventoryPrice(merchant_id: String): Result[BigDecimal] = {
+    val result = Try(DB localTx { implicit session =>
+      sql"""SELECT inventory_price
+        FROM merchants
+        WHERE merchant_id = $merchant_id"""
+        .map(rs => rs.bigDecimal("inventory_price")).list.apply().headOption.get
+    })
+    result match {
+      case scala.util.Success(price) =>
+        Success(price)
+      case scala.util.Failure(e) =>
+        Failure(e.getMessage, 500)
+    }
+  }
+
   def changeInventoryPrice(price: BigDecimal, merchant_id: String): Result[Merchant] = {
     val res = Try(DB localTx { implicit session =>
       sql"""UPDATE merchants
@@ -751,7 +766,7 @@ object DatabaseStore {
     })
     res match {
       case scala.util.Success(merchant) =>
-        logInventoryPrice(price,merchant_id)
+        logInventoryPrice(price, merchant_id)
         Success(merchant)
       case scala.util.Failure(e) =>
         Failure(e.getMessage, 500)

--- a/src/main/scala/de/hpi/epic/pricewars/services/MarketplaceService.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/services/MarketplaceService.scala
@@ -298,14 +298,14 @@ trait MarketplaceService extends HttpService with CORSSupport {
         path("inventory_price") {
           put {
             entity(as[InventoryPrice]) { inventory_price =>
-              inventory_price.merchant_id match {
-                case Some(id) =>
-                  DatabaseStore.changeInventoryPrice(inventory_price.price, id)
-                case None =>
-                  default_inventory_price = inventory_price.price
-              }
               complete {
-                StatusCode.int2StatusCode(200) -> s"""{}"""
+                inventory_price.merchant_id match {
+                  case Some(id) =>
+                    DatabaseStore.changeInventoryPrice(inventory_price.price, id)
+                  case None =>
+                    default_inventory_price = inventory_price.price
+                    StatusCode.int2StatusCode(200) -> s"""{}"""
+                }
               }
             }
           }

--- a/src/main/scala/de/hpi/epic/pricewars/services/MarketplaceService.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/services/MarketplaceService.scala
@@ -296,6 +296,16 @@ trait MarketplaceService extends HttpService with CORSSupport {
               }
           } ~
         path("inventory_price") {
+          get {
+            optionalHeaderValueByName(HttpHeaders.Authorization.name) { authorizationHeader =>
+              complete {
+                DatabaseStore.getMerchantByToken(ValidateLimit.getTokenString(authorizationHeader).getOrElse(""))
+                  .flatMap(merchant => {
+                    DatabaseStore.getInventoryPrice(merchant.merchant_id.get)
+                  })
+              }
+            }
+          } ~
           put {
             entity(as[InventoryPrice]) { inventory_price =>
               complete {


### PR DESCRIPTION
Add a GET route that can be called by the merchant to get its current holding cost rate.
Previously, the marketplace sent the new holding cost rate to Kafka.
Now the marketplace must remember the current holding cost rate for each merchant the answer the GET request.
Do to that, the rate is saved to the database.

The new route is:
GET /holding_cost_rate
and requires an authorisation header.

Remove unused options from the getMerchant function.