### PR TITLE
Don't execute SQL files to preregister merchants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM hseeberger/scala-sbt:latest
 
-RUN apt-get update -qq
-RUN apt-get install -y postgresql
-
 ENV APP_HOME /marketplace
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME

--- a/start-marketplace.sh
+++ b/start-marketplace.sh
@@ -1,30 +1,8 @@
 #!/bin/bash
 
 POSTGRES_URL=jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB
-PGPASSWORD=$POSTGRES_PASSWORD
-
-if [[ $PRICEWARS_PRODUCER_URL != http://* ]];then
-    PRICEWARS_PRODUCER_URL=http://$PRICEWARS_PRODUCER_URL
-    export PRICEWARS_PRODUCER_URL
-fi
 
 export POSTGRES_URL
-export PGPASSWORD
 
 /marketplace/wait-for-it.sh postgres:5432 -t 0
-sbt ~tomcat:start &
-
-# Getting the process and waiting for it to ensure the container will stay up
-PID_MARKETPLACE=$!
-
-/marketplace/wait-for-it.sh marketplace:8080 -t 0
-sleep 20
-
-for file in /db-seeds/*; do
-    if [ "${file}" != "${file%.sql}" ];then
-        echo "Processing $file ..."
-        psql -a -d $POSTGRES_DB -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -f $file
-    fi
-done
-
-wait $PID_MARKETPLACE
+sbt ~tomcat:start


### PR DESCRIPTION
Merchants are able to register themselves. That's why it is no longer necessary to preregister merchants with the SQL scripts in the db-seeds directory. This also removes the dependency to the main pricewars repo which contains db-seeds.

Remove the environment variable PGPASSWORD. It is only used in _src/test/resources/application.codeship.conf_. I assume that this file is not used in the docker context because it also needs the variable PGUSER which is not set anywhere.

Don't append the protocol to PRICEWARS_PRODUCER_URL. Instead require the variable to be in the right form from the beginning. If this check is really wanted, it should be done be the application.