### PR TITLE
Reduce docker image build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:latest
+FROM hseeberger/scala-sbt:8u141-jdk_2.12.3_0.13.16
 
 ENV APP_HOME /marketplace
 RUN mkdir $APP_HOME

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.16


### PR DESCRIPTION
Increase the sbt version to 0.13.16 and use a docker image with the same sbt version.
This docker images is actually newer than the [latest image](https://hub.docker.com/r/hseeberger/scala-sbt/tags/).

This reduces the image build time from 4:17 to 1:16 on my machine.
The newer sbt version could be building faster. But the main performance increase is because the sbt version from the docker image can be used. Previously sbt 0.13.8 was downloaded separately.
Sbt in version 1.x could be faster but it is more difficult to migrate to that version.