### PR TITLE
Increase internal request timeout

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,7 +19,7 @@ scalikejdbc.global.loggingSQLAndTime {
 spray {
   servlet {
     boot-class = "de.hpi.epic.pricewars.Server"
-    request-timeout = 2s
+    request-timeout = 20s
   }
 
   can {


### PR DESCRIPTION
My old laptop is sometimes not fast enough to process a request within 2 seconds.
If so, the marketplace responds with HTTP code 500 and the message "The server was not able to produce a timely response to your request."

Weaker machines run the pricewars platform just fine if the timeout is increased.