### PR TITLE
Correctly validate offer amount

### DIFF
--- a/src/main/scala/de/hpi/epic/pricewars/connectors/ProducerConnector.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/connectors/ProducerConnector.scala
@@ -65,7 +65,7 @@ object ProducerConnector {
     val producer_infos = encrypted_signature.split(" ")
 
     try {
-      if (producer_infos{0}.toLong == uid && producer_infos{1}.toInt == amount && producer_infos{2} == merchant_id) {
+      if (producer_infos{0}.toLong == uid && producer_infos{2} == merchant_id) {
         val totalAmountUsed = DatabaseStore.getUsedAmountForSignature(signature) + amount
 
         if (totalAmountUsed <= producer_infos{1}.toInt) {


### PR DESCRIPTION
Without the additional condition it is possible to upload the same offer with different amounts. 
E.g. if a product is ordered with amount 50, you can now upload the offer first with amount 20, and then again with amount 30.