### PR TITLE
Improve offer validation

### DIFF
--- a/src/main/scala/de/hpi/epic/pricewars/connectors/ProducerConnector.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/connectors/ProducerConnector.scala
@@ -24,7 +24,6 @@ object ProducerConnector {
 
   val producer_url: String = config.getString("producer_url")
   var producer_key: Option[String] = None
-  var producer_key_updated = new DateTime()
 
   implicit val system: ActorSystem = ActorSystem()
   implicit val timeout: Timeout = Timeout(15.seconds)
@@ -47,10 +46,9 @@ object ProducerConnector {
   }
 
   def validSignature(uid: Long, amount: Int, signature: String, merchant_id: String): Boolean = {
-    // "<product_uid> <amount> <merchant_id> <timestamp>"
+    // A valid signature consists of: <product_uid> <amount> <merchant_id> <timestamp>
     if (producer_key.isEmpty) {
       producer_key = getProducerKey()
-      producer_key_updated = new DateTime()
     }
 
     if (signature.length == 0 || producer_key.isEmpty) {
@@ -62,31 +60,24 @@ object ProducerConnector {
     val cipher: Cipher = Cipher.getInstance("AES/ECB/NoPadding")
     cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(decryption_key_bytes, "AES"))
     val encrypted_signature = new String(cipher.doFinal(signature_bytes)).trim
-    val producer_infos = encrypted_signature.split(" ")
+    val signature_content = encrypted_signature.split(" ")
+
+    if (signature_content.length != 4) {
+      println("Signature invalid format")
+      return false
+    }
 
     try {
-      if (producer_infos{0}.toLong == uid && producer_infos{1}.toInt == amount && producer_infos{2} == merchant_id) {
-        val totalAmountUsed = DatabaseStore.getUsedAmountForSignature(signature) + amount
-
-        if (totalAmountUsed <= producer_infos{1}.toInt) {
-          DatabaseStore.setUsedAmountForSignature(signature, totalAmountUsed)
-        } else {
-          false
-        }
+      if (signature_content{0}.toLong == uid && signature_content{1}.toInt <= amount && signature_content{2} == merchant_id) {
+        true
       } else {
         false
       }
     } catch {
-      case e: Exception => {
-        if (Minutes.minutesBetween(producer_key_updated, new DateTime()).getMinutes > 15) {
-          println("Signature invalid, updating key!")
-          producer_key = None
-          validSignature(uid, amount, signature, merchant_id)
-        } else {
-          println("Signature invalid, last update less than 15 minutes ago!")
-          println(e)
-          false
-        }
+      case e: java.lang.NumberFormatException => {
+        println("Signature invalid format")
+        println(e)
+        false
       }
     }
   }

--- a/src/main/scala/de/hpi/epic/pricewars/data/EncryptedSignature.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/data/EncryptedSignature.scala
@@ -1,0 +1,3 @@
+package de.hpi.epic.pricewars.data
+
+case class EncryptedSignature (signature: String)

--- a/src/main/scala/de/hpi/epic/pricewars/data/Signature.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/data/Signature.scala
@@ -1,0 +1,13 @@
+package de.hpi.epic.pricewars.data
+
+case class Signature (
+  product_uid: Long,
+  max_amount: Int,
+  merchant_id: String) {
+
+  def isValid(product_uid: Long, amount: Int, merchant_id: String): Boolean = {
+    return (this.product_uid == product_uid
+      && amount <= max_amount
+      && this.merchant_id == merchant_id)
+  }
+}

--- a/src/main/scala/de/hpi/epic/pricewars/services/MarketplaceService.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/services/MarketplaceService.scala
@@ -82,11 +82,12 @@ trait MarketplaceService extends HttpService with CORSSupport {
             } ~
               delete {
                 optionalHeaderValueByName(HttpHeaders.Authorization.name) { authorizationHeader =>
-                  complete {
-                    ValidateLimit
-                      .checkMerchant(authorizationHeader)
-                      .flatMap(merchant => DatabaseStore.deleteOffer(id, merchant))
-                      .successHttpCode(StatusCodes.NoContent)
+                  entity(as[EncryptedSignature]) { signature =>
+                    complete {
+                      ValidateLimit
+                        .checkMerchant(authorizationHeader)
+                        .flatMap(merchant => DatabaseStore.deleteOffer(id, merchant, signature))
+                    }
                   }
                 }
               } ~

--- a/src/main/scala/de/hpi/epic/pricewars/utils/JSONConverter.scala
+++ b/src/main/scala/de/hpi/epic/pricewars/utils/JSONConverter.scala
@@ -14,5 +14,6 @@ object JSONConverter extends DefaultJsonProtocol with SprayJsonSupport {
   implicit val buyRequestFormat = jsonFormat3(BuyRequest)
   implicit val settingsFormat = jsonFormat3(Settings)
   implicit val holdingCostRateFormat: RootJsonFormat[HoldingCostRate] = jsonFormat2(HoldingCostRate)
+  implicit val encryptedSignatureFormat = jsonFormat1(EncryptedSignature)
   implicit def failureFormat[A :JsonFormat] = jsonFormat2(Failure.apply[A])
 }


### PR DESCRIPTION
With this PR merchants can remove offers and offer the products again (#6). It's now possible to offer part of the products ordered from the producer.

The signature system worked this way: The marketplace remembers how many items a merchants adds to the marketplace for each signature. The number of items must not exceed the amount specified in the signature.
I changed the code to reduce this number when a merchant removes an offer from the marketplace. This is problematic because we don't now to which signatures an offer belongs to. Now, merchants must provide a signature when removing an offer. They "get the products back" for this signature.
An open problem is when a merchant removes an offer with more items than the amount specified in the signature. In that case, the merchant gets only as many items back as the signature allows.

Validating the signature (now done in `Signature.isValid()`) no longer changes marketplace state.

I removed the code for getting the new producer key. It caused invalid signatures for up to 15 minutes. If we want support changing producer keys, there should be a better way to do that.

Would be nice: if the merchant gets to know how many items got back by removing the offer.